### PR TITLE
feat: Admin Event 및 TrendPost 이미지 s3 업로드 기능 구현

### DIFF
--- a/AdminService/build.gradle
+++ b/AdminService/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 
     // eureka client
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.547' // 최신 버전 확인
+
 }
 
 tasks.named('test') {

--- a/AdminService/src/main/java/ready_to_marry/adminservice/common/util/S3Config.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/common/util/S3Config.java
@@ -1,0 +1,34 @@
+package ready_to_marry.adminservice.common.util;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(
+                        new AWSStaticCredentialsProvider(
+                                new BasicAWSCredentials(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}

--- a/AdminService/src/main/java/ready_to_marry/adminservice/common/util/S3Uploader.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/common/util/S3Uploader.java
@@ -1,12 +1,58 @@
 package ready_to_marry.adminservice.common.util;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
 @Component
+@RequiredArgsConstructor
 public class S3Uploader {
-    public String upload(MultipartFile file, String dirName) {
-        // TODO: S3 업로드 로직 실제 구현 필요
-        return "https://s3.fake-bucket.com/" + dirName + "/" + file.getOriginalFilename();
+
+    private final AmazonS3 amazonS3;
+    private final String bucketName = "rtm-app-bucket"; // 또는 @Value 로 주입
+
+    /**
+     * 1. 폴더 기준 업로드 (파일명 자동 생성)
+     * ex) uploadToFolder(file, "admin/events")
+     */
+    public String uploadToFolder(MultipartFile file, String dirName) {
+        String fileName = dirName + "/" + System.currentTimeMillis() + "-" + file.getOriginalFilename();
+        return putAndReturnUrl(file, fileName);
+    }
+
+    /**
+     * 2. Key 직접 지정 업로드
+     * ex) uploadWithKey(file, "admin/events/event-123.jpg")
+     */
+    public String uploadWithKey(MultipartFile file, String key) {
+        return putAndReturnUrl(file, key);
+    }
+
+    /**
+     * 3. 파일 삭제
+     */
+    public void delete(String key) {
+        amazonS3.deleteObject(bucketName, key);
+    }
+
+    /**
+     * 내부 공통 업로드 로직
+     */
+    private String putAndReturnUrl(MultipartFile file, String key) {
+        try {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(file.getSize());
+            metadata.setContentType(file.getContentType());
+
+            amazonS3.putObject(bucketName, key, file.getInputStream(), metadata);
+
+            return amazonS3.getUrl(bucketName, key).toString();
+        } catch (IOException e) {
+            throw new RuntimeException("S3 업로드 실패", e);
+        }
     }
 }

--- a/AdminService/src/main/java/ready_to_marry/adminservice/trendpost/service/TrendPostServiceImpl.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/trendpost/service/TrendPostServiceImpl.java
@@ -24,24 +24,34 @@ public class TrendPostServiceImpl implements TrendPostService {
     private final TrendPostRepository repository;
     private final S3Uploader s3Uploader;
 
-    // 1. Admin -> 등록
+    // 1. Admin → 등록
     @Override
     @Transactional
     public TrendPostDetailResponse create(TrendPostRequest request, MultipartFile thumbnail, MultipartFile contentImage, Long adminId) {
-        String thumbnailUrl = s3Uploader.upload(thumbnail, "trendposts/thumbnails");
-        String contentImageUrl = s3Uploader.upload(contentImage, "trendposts/content");
-
+        // 1) 먼저 저장 (이미지 제외)
         TrendPost post = TrendPost.builder()
                 .title(request.getTitle())
-                .thumbnailUrl(thumbnailUrl)
-                .contentImageUrl(contentImageUrl)
                 .adminId(adminId)
                 .build();
+        repository.save(post); // postId 생성
 
-        return TrendPostDetailResponse.from(repository.save(post));
+        Long postId = post.getTrendPostId();
+
+        // 2) S3 업로드 (postId 포함한 고유 키)
+        String thumbnailKey = String.format("admin/trendposts/thumbnails/post-%d.jpg", postId);
+        String contentKey = String.format("admin/trendposts/content/post-%d-content.jpg", postId);
+
+        String thumbnailUrl = s3Uploader.uploadWithKey(thumbnail, thumbnailKey);
+        String contentImageUrl = s3Uploader.uploadWithKey(contentImage, contentKey);
+
+        // 3) 이미지 URL 저장
+        post.setThumbnailUrl(thumbnailUrl);
+        post.setContentImageUrl(contentImageUrl);
+
+        return TrendPostDetailResponse.from(post);
     }
 
-    // 2. Admin -> 수정 (이미지 선택적 변경)
+    // 2. Admin → 수정 (이미지 선택적 변경)
     @Override
     @Transactional
     public TrendPostDetailResponse update(Long id, TrendPostRequest request, MultipartFile thumbnail, MultipartFile contentImage, Long adminId) {
@@ -55,19 +65,21 @@ public class TrendPostServiceImpl implements TrendPostService {
         post.setTitle(request.getTitle());
 
         if (thumbnail != null && !thumbnail.isEmpty()) {
-            String thumbnailUrl = s3Uploader.upload(thumbnail, "trendposts/thumbnails");
+            String thumbnailKey = String.format("admin/trendposts/thumbnails/post-%d.jpg", id);
+            String thumbnailUrl = s3Uploader.uploadWithKey(thumbnail, thumbnailKey);
             post.setThumbnailUrl(thumbnailUrl);
         }
 
         if (contentImage != null && !contentImage.isEmpty()) {
-            String contentImageUrl = s3Uploader.upload(contentImage, "trendposts/content");
+            String contentKey = String.format("admin/trendposts/content/post-%d-content.jpg", id);
+            String contentImageUrl = s3Uploader.uploadWithKey(contentImage, contentKey);
             post.setContentImageUrl(contentImageUrl);
         }
 
         return TrendPostDetailResponse.from(post);
     }
 
-    // 3. Admin -> 삭제
+    // 3. Admin → 삭제
     @Override
     @Transactional
     public void delete(Long id, Long adminId) {
@@ -78,10 +90,16 @@ public class TrendPostServiceImpl implements TrendPostService {
             throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
+//        //S3 이미지 삭제 로직 추가 가능
+//        String thumbKey = String.format("admin/trendposts/thumbnails/post-%d.jpg", id);
+//        String contentKey = String.format("admin/trendposts/content/post-%d-content.jpg", id);
+//        // \\s3Uploader.delete(thumbKey);
+//        // s3Uploader.delete(contentKey);
+
         repository.delete(post);
     }
 
-    // 4. 전체 목록
+    // 4. 전체 목록 조회
     @Override
     public TrendPostPagedResponse getAllPaged(int page, int size) {
         Pageable pageable = PageRequest.of(page - 1, size);


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 관리자용 이벤트 및 트렌드포스트 등록/수정 시 이미지 업로드 기능에 대한 AWS S3 연동 구현

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
1. `S3Uploader` 유틸 클래스 구현
   - `uploadToFolder()`, `uploadWithKey()`로 역할 분리
   - `AmazonS3` Bean 주입 방식 적용
2. `TrendPostServiceImpl`, `EventServiceImpl` 업로드 로직 리팩토링
   - entity 저장 후 ID 기반 Key로 고정된 파일명 구성
   - S3 업로드 후 해당 URL을 entity에 반영
3. 등록/수정 API에서 이미지 업로드 반영
   - 등록 시 ID 기반 이미지 저장
   - 수정 시 이미지가 있을 경우에만 재업로드
4. 관리자 컨트롤러 (`AdminTrendPostController`, `AdminEventController`)
   - `@RequestPart` 기반 multipart/form-data 요청 처리 구현

## 📸 스크린샷 (Optional)
x

## 🔗 관련 이슈 (Linked Issue)
x

## 📌 참고 사항 (Additional Notes)
x
