### PR TITLE
Feat/admin service review

### DIFF
--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/controller/AdminEventController.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/controller/AdminEventController.java
@@ -6,7 +6,10 @@ import org.springframework.web.multipart.MultipartFile;
 import ready_to_marry.adminservice.common.dto.ApiResponse;
 import ready_to_marry.adminservice.event.dto.request.EventCreateRequest;
 import ready_to_marry.adminservice.event.dto.request.EventUpdateRequest;
+import ready_to_marry.adminservice.event.dto.response.AdminEventResponse;
 import ready_to_marry.adminservice.event.service.EventService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/events/admin")
@@ -42,4 +45,9 @@ public class AdminEventController {
         return ApiResponse.success(null);
     }
 
+    // 4. Admin -> 전체 이벤트 목록 조회
+    @GetMapping
+    public ApiResponse<List<AdminEventResponse>> getAllAdminEvents() {
+        return ApiResponse.success(service.getAdminEventList());
+    }
 }

--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/request/EventCreateRequest.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/request/EventCreateRequest.java
@@ -19,6 +19,5 @@ public class EventCreateRequest {
     private String title;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-
     private Long targetId; // 상품 특가(SD)일 경우 itemId, 쿠폰(CE)일 경우 couponId
 }

--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/request/EventUpdateRequest.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/request/EventUpdateRequest.java
@@ -15,10 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class EventUpdateRequest {
-    private LinkType linkType;
     private String title;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-
-    private Long targetId; // 상품 특가(SD)일 경우 itemId, 쿠폰(CE)일 경우 couponId
 }

--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/response/AdminEventResponse.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/response/AdminEventResponse.java
@@ -1,0 +1,48 @@
+package ready_to_marry.adminservice.event.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import ready_to_marry.adminservice.event.entity.Event;
+import ready_to_marry.adminservice.event.enums.LinkType;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class AdminEventResponse {
+
+    private Long eventId;
+
+    private LinkType linkType; // "SD" 또는 "CE"
+
+    private String title;
+
+    private String thumbnailImageUrl;
+
+    private String linkUrl;
+
+    private Long targetId;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
+
+    private Long adminId;
+
+    private LocalDateTime createdAt;
+
+    public static AdminEventResponse from(Event event) {
+        return AdminEventResponse.builder()
+                .eventId(event.getEventId())
+                .linkType(event.getLinkType())
+                .title(event.getTitle())
+                .thumbnailImageUrl(event.getThumbnailImageUrl())
+                .linkUrl(event.getLinkUrl())
+                .targetId(event.getTargetId())
+                .startDate(event.getStartDate())
+                .endDate(event.getEndDate())
+                .adminId(event.getAdminId())
+                .createdAt(event.getCreatedAt())
+                .build();
+    }
+}

--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/response/CouponDetailResponse.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/response/CouponDetailResponse.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class CouponDetailResponse {
+    // Admin -> 쿠폰 이벤트 관리 -> 상세 조회
     private Long couponId;
     private String title;
     private String discountType;

--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/response/EventBannerResponse.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/response/EventBannerResponse.java
@@ -7,6 +7,7 @@ import ready_to_marry.adminservice.event.entity.Event;
 @Getter
 @Builder
 public class EventBannerResponse {
+    // User -> 메인 베너 조회
     private Long eventId;
     private String thumbnailImageUrl;
     private String linkUrl;

--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/response/EventDTO.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/response/EventDTO.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class EventDTO {
+    // User -> 이벤트 목록 조회
     private Long eventId;
     private String title;
     private String thumbnailImageUrl;

--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/response/EventDetailResponse.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/dto/response/EventDetailResponse.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class EventDetailResponse {
-
+    // User -> 쿠폰 이벤트 클릭 -> 쿠폰 이벤트 상세 조회
     // 쿠폰 정보
     private Long couponId;
     private String title;

--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/service/EventService.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/service/EventService.java
@@ -5,6 +5,8 @@ import ready_to_marry.adminservice.event.dto.request.EventCreateRequest;
 import ready_to_marry.adminservice.event.dto.request.EventUpdateRequest;
 import ready_to_marry.adminservice.event.dto.response.*;
 
+import java.util.List;
+
 public interface EventService {
 
     // 1. 이벤트 등록
@@ -21,4 +23,7 @@ public interface EventService {
 
     // 5. 전체 이벤트 목록 페이징 조회
     EventPagedResponse getPagedEvents(int page, int size);
+
+    // 6. Admin → 전체 이벤트 목록 조회
+    List<AdminEventResponse> getAdminEventList();
 }

--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/service/EventServiceImpl.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/service/EventServiceImpl.java
@@ -27,7 +27,7 @@ public class EventServiceImpl implements EventService {
     private final S3Uploader s3Uploader;
     private final CouponService couponService;
 
-    // 1. 이벤트 등록
+    // 1. Admin -> 이벤트 등록
     @Override
     @Transactional
     public void createEvent(EventCreateRequest request, MultipartFile image, Long adminId) {
@@ -63,7 +63,7 @@ public class EventServiceImpl implements EventService {
         event.setLinkUrl(linkUrl);
     }
 
-    // 2. 이벤트 수정
+    // 2. Admin -> 이벤트 수정
     @Override
     @Transactional
     public void updateEvent(Long eventId, EventUpdateRequest request, MultipartFile image, Long adminId) {
@@ -107,7 +107,7 @@ public class EventServiceImpl implements EventService {
         // s3Uploader.delete(imageKey);
     }
 
-    // 4. 상세 조회
+    // 4. User -> 이벤트 조회 -> 상세 조회
     @Override
     public EventDetailResponse getEventDetail(Long eventId) {
         Event event = eventRepository.findById(eventId)
@@ -121,7 +121,7 @@ public class EventServiceImpl implements EventService {
         throw new IllegalStateException("쿠폰 이벤트가 아닌 이벤트는 상세 정보를 제공하지 않습니다.");
     }
 
-    // 5. 전체 이벤트 목록 조회 (페이징)
+    // 5. User -> 전체 이벤트 목록 조회
     @Override
     public EventPagedResponse getPagedEvents(int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
@@ -137,5 +137,14 @@ public class EventServiceImpl implements EventService {
                 .size(result.getSize())
                 .total((int) result.getTotalElements())
                 .build();
+    }
+
+    // 6. Admin → 전체 이벤트 목록 조회
+    @Override
+    public List<AdminEventResponse> getAdminEventList() {
+        return eventRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"))
+                .stream()
+                .map(AdminEventResponse::from)
+                .collect(Collectors.toList());
     }
 }

--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/service/EventServiceImpl.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/service/EventServiceImpl.java
@@ -70,23 +70,28 @@ public class EventServiceImpl implements EventService {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new NotFoundException("이벤트를 찾을 수 없습니다."));
 
-        if (!event.getLinkType().equals(request.getLinkType()) ||
-                !event.getTargetId().equals(request.getTargetId())) {
-            throw new IllegalStateException("linkType 또는 targetId는 수정할 수 없습니다. 삭제 후 다시 등록해주세요.");
-        }
 
         // 1) 이미지가 있으면 새로 업로드
-        String imageUrl = event.getThumbnailImageUrl();
         if (image != null && !image.isEmpty()) {
             String imageKey = String.format("admin/events/event-%d.jpg", eventId);
-            imageUrl = s3Uploader.uploadWithKey(image, imageKey);
+            String imageUrl = s3Uploader.uploadWithKey(image, imageKey);
+            event.setThumbnailImageUrl(imageUrl);
         }
 
         // 2) 필드 갱신
-        event.setTitle(request.getTitle());
-        event.setStartDate(request.getStartDate());
-        event.setEndDate(request.getEndDate());
-        event.setThumbnailImageUrl(imageUrl);
+        String title = request.getTitle();
+        LocalDateTime startDate = request.getStartDate();
+        LocalDateTime endDate = request.getEndDate();
+
+        if (title != null && !title.isEmpty()) {
+            event.setTitle(title);
+        }
+        if (startDate != null) {
+            event.setStartDate(startDate);
+        }
+        if (endDate != null) {
+            event.setEndDate(endDate);
+        }
     }
 
     // 3. 이벤트 삭제

--- a/AdminService/src/main/java/ready_to_marry/adminservice/mainbanner/controller/MainBannerController.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/mainbanner/controller/MainBannerController.java
@@ -3,6 +3,7 @@ package ready_to_marry.adminservice.mainbanner.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import ready_to_marry.adminservice.mainbanner.dto.request.MainBannerRequest;
+import ready_to_marry.adminservice.mainbanner.dto.response.AdminMainBannerResponse;
 import ready_to_marry.adminservice.mainbanner.dto.response.MainBannerResponse;
 import ready_to_marry.adminservice.mainbanner.service.MainBannerService;
 import ready_to_marry.adminservice.common.dto.ApiResponse;
@@ -16,7 +17,7 @@ public class MainBannerController {
 
     private final MainBannerService service;
 
-    // 1. 메인 배너 등록
+    // 1. Admin -> 메인 배너 등록
     @PostMapping("/admin")
     public ApiResponse<Void> register(@RequestBody MainBannerRequest request,
                                       @RequestHeader("X-ADMIN-ID") Long adminId) {
@@ -24,7 +25,7 @@ public class MainBannerController {
         return ApiResponse.success(null);
     }
 
-    // 2. 메인 배너 수정
+    // 2. Admin -> 메인 배너 수정
     @PatchMapping("/admin/{mainBannerId}")
     public ApiResponse<Void> update(@PathVariable Long mainBannerId,
                                     @RequestBody MainBannerRequest request,
@@ -33,7 +34,7 @@ public class MainBannerController {
         return ApiResponse.success(null);
     }
 
-    // 3. 메인 배너 삭제
+    // 3. Admin -> 메인 배너 삭제
     @DeleteMapping("/admin/{mainBannerId}")
     public ApiResponse<Void> delete(@PathVariable Long mainBannerId,
                                     @RequestHeader("X-ADMIN-ID") Long adminId) {
@@ -41,7 +42,13 @@ public class MainBannerController {
         return ApiResponse.success(null);
     }
 
-    // 4. 메인 배너 전체 조회 (공개 API)
+    // 4. Admin -> 메인 배너 전체 조회 (관리용 상세 정보 포함)
+    @GetMapping("/admin")
+    public ApiResponse<List<AdminMainBannerResponse>> getAdminAll() {
+        return ApiResponse.success(service.getAdminAll());
+    }
+
+    // 5. User -> 메인 배너 전체 조회 (일반 사용자용 공개 API)
     @GetMapping
     public ApiResponse<List<MainBannerResponse>> getAll() {
         return ApiResponse.success(service.getAll());

--- a/AdminService/src/main/java/ready_to_marry/adminservice/mainbanner/dto/response/AdminMainBannerResponse.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/mainbanner/dto/response/AdminMainBannerResponse.java
@@ -1,0 +1,16 @@
+package ready_to_marry.adminservice.mainbanner.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import ready_to_marry.adminservice.mainbanner.enums.BannerType;
+
+@Data
+@Builder
+public class AdminMainBannerResponse {
+    private Long mainBannerId;
+    private BannerType type;
+    private Long refId;
+    private String thumbnailImageUrl;
+    private String linkUrl;
+    private int priority;
+}

--- a/AdminService/src/main/java/ready_to_marry/adminservice/mainbanner/service/MainBannerService.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/mainbanner/service/MainBannerService.java
@@ -1,21 +1,25 @@
 package ready_to_marry.adminservice.mainbanner.service;
 
 import ready_to_marry.adminservice.mainbanner.dto.request.MainBannerRequest;
+import ready_to_marry.adminservice.mainbanner.dto.response.AdminMainBannerResponse;
 import ready_to_marry.adminservice.mainbanner.dto.response.MainBannerResponse;
 
 import java.util.List;
 
 public interface MainBannerService {
 
-    // 1. 메인 배너 등록
+    // 1. Admin -> 메인 배너 등록
     void register(MainBannerRequest request, Long adminId);
 
-    // 2. 메인 배너 수정
+    // 2. Admin -> 메인 배너 수정
     void update(Long id, MainBannerRequest request, Long adminId);
 
-    // 3. 메인 배너 삭제
+    // 3. Admin -> 메인 배너 삭제
     void delete(Long id, Long adminId);
 
-    // 4. 메인 배너 전체 조회
+    // 4. Admin -> 메인 배너 상세 조회
+    List<AdminMainBannerResponse> getAdminAll();
+
+    // 5. User -> 메인 배너 전체 조회
     List<MainBannerResponse> getAll();
 }

--- a/AdminService/src/main/java/ready_to_marry/adminservice/mainbanner/service/MainBannerServiceImpl.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/mainbanner/service/MainBannerServiceImpl.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import ready_to_marry.adminservice.mainbanner.dto.request.MainBannerRequest;
+import ready_to_marry.adminservice.mainbanner.dto.response.AdminMainBannerResponse;
 import ready_to_marry.adminservice.mainbanner.dto.response.MainBannerResponse;
 import ready_to_marry.adminservice.mainbanner.entity.MainBanner;
 import ready_to_marry.adminservice.mainbanner.enums.BannerType;
@@ -24,6 +25,7 @@ public class MainBannerServiceImpl implements MainBannerService {
     private final EventRepository eventRepository;
     private final TrendPostRepository trendPostRepository;
 
+    // 1. 메인 배너 등록 (Admin)
     @Transactional
     @Override
     public void register(MainBannerRequest request, Long adminId) {
@@ -36,15 +38,16 @@ public class MainBannerServiceImpl implements MainBannerService {
         bannerRepository.save(banner);
     }
 
+    // 2. 메인 배너 수정 (Admin)
     @Transactional
     @Override
     public void update(Long mainBannerId, MainBannerRequest request, Long adminId) {
         MainBanner banner = bannerRepository.findById(mainBannerId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 배너입니다."));
-
         banner.update(request.getType(), request.getRefId(), request.getPriority(), adminId);
     }
 
+    // 3. 메인 배너 삭제 (Admin)
     @Transactional
     @Override
     public void delete(Long id, Long adminId) {
@@ -53,6 +56,15 @@ public class MainBannerServiceImpl implements MainBannerService {
         bannerRepository.delete(banner);
     }
 
+    // 4. 메인 배너 전체 목록 조회 (Admin - 상세 정보 포함)
+    @Override
+    public List<AdminMainBannerResponse> getAdminAll() {
+        return bannerRepository.findAllByOrderByPriorityAsc().stream()
+                .map(this::toAdminResponse)
+                .collect(Collectors.toList());
+    }
+
+    // 5. 메인 배너 전체 목록 조회 (User - 썸네일, 링크만 제공)
     @Override
     public List<MainBannerResponse> getAll() {
         return bannerRepository.findAllByOrderByPriorityAsc().stream()
@@ -60,6 +72,7 @@ public class MainBannerServiceImpl implements MainBannerService {
                 .collect(Collectors.toList());
     }
 
+    // 5-1. User 응답용 DTO 변환
     private MainBannerResponse toResponse(MainBanner banner) {
         if (banner.getType() == BannerType.EVENT) {
             Event event = eventRepository.findById(banner.getRefId())
@@ -76,6 +89,35 @@ public class MainBannerServiceImpl implements MainBannerService {
 
             return MainBannerResponse.builder()
                     .mainBannerId(banner.getMainBannerId())
+                    .thumbnailImageUrl(post.getThumbnailUrl())
+                    .linkUrl("/trend-posts/" + post.getTrendPostId())
+                    .build();
+        }
+    }
+
+    // 4-1. Admin 응답용 DTO 변환
+    private AdminMainBannerResponse toAdminResponse(MainBanner banner) {
+        if (banner.getType() == BannerType.EVENT) {
+            Event event = eventRepository.findById(banner.getRefId())
+                    .orElseThrow(() -> new IllegalArgumentException("이벤트 정보 없음"));
+
+            return AdminMainBannerResponse.builder()
+                    .mainBannerId(banner.getMainBannerId())
+                    .type(banner.getType())
+                    .refId(banner.getRefId())
+                    .priority(banner.getPriority())
+                    .thumbnailImageUrl(event.getThumbnailImageUrl())
+                    .linkUrl(event.getLinkUrl())
+                    .build();
+        } else {
+            TrendPost post = trendPostRepository.findById(banner.getRefId())
+                    .orElseThrow(() -> new IllegalArgumentException("트렌드포스트 정보 없음"));
+
+            return AdminMainBannerResponse.builder()
+                    .mainBannerId(banner.getMainBannerId())
+                    .type(banner.getType())
+                    .refId(banner.getRefId())
+                    .priority(banner.getPriority())
                     .thumbnailImageUrl(post.getThumbnailUrl())
                     .linkUrl("/trend-posts/" + post.getTrendPostId())
                     .build();


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- Event 수정 시 수정 불가 필드(linkType, targetId)에 대한 제약을 추가
- Admin Event 전체 목록 조회 API 및 메인 배너 상세 조회 API 구현

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
**1. 이벤트 수정 시 `linkType`, `targetId` 수정 방지 로직 추가**
  - `EventServiceImpl.updateEvent()`에서 해당 필드 변경 무시
  - 불필요한 로직 제거
 
**2. Admin 전용 이벤트 목록 조회 기능 구현**
  - `AdminEventResponse` DTO 생성 (Event 전체 필드 포함)
  - `EventService`, `EventServiceImpl`: `getAdminEventList()` 추가
  - `AdminEventController`: `GET /events/admin` 엔드포인트 구현
 
**3. Admin 전용 메인 배너 상세 조회 기능 구현**
  - `AdminMainBannerResponse` DTO 생성
  - `MainBannerService`, `MainBannerServiceImpl`: `getAdminAll()` 구현
  - `MainBannerController`: `GET /main-banners/admin` 엔드포인트 구현
  
## 📸 스크린샷 (Optional)
x

## 🔗 관련 이슈 (Linked Issue)
x

## 📌 참고 사항 (Additional Notes)
x