### PR TITLE
feat: Internal Admin-id 조회/생성 API 구현

### DIFF
--- a/AdminService/build.gradle
+++ b/AdminService/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.547' // 최신 버전 확인
 
+    // Logstash Logback Encoder (JSON 로그 포맷용)
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.3'
+
 }
 
 tasks.named('test') {

--- a/AdminService/src/main/java/ready_to_marry/adminservice/profile/controller/InternalAdminController.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/profile/controller/InternalAdminController.java
@@ -1,0 +1,24 @@
+package ready_to_marry.adminservice.profile.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import ready_to_marry.adminservice.profile.dto.request.AdminProfileRequest;
+import ready_to_marry.adminservice.profile.dto.response.AdminIdResponse;
+import ready_to_marry.adminservice.profile.service.InternalAdminService;
+import ready_to_marry.adminservice.common.dto.ApiResponse;
+
+@RestController
+@RequestMapping("/internal")
+@RequiredArgsConstructor
+public class InternalAdminController {
+
+    private final InternalAdminService internalAdminService;
+
+    // 내부 서비스 간 통신용 API
+    @PostMapping("/admin-id")
+    public ApiResponse<AdminIdResponse> getOrCreateAdminId(@RequestBody AdminProfileRequest request) {
+        Long adminId = internalAdminService.getOrCreateAdminId(request);
+        return ApiResponse.success(new AdminIdResponse(adminId));
+    }
+
+}

--- a/AdminService/src/main/java/ready_to_marry/adminservice/profile/dto/request/AdminProfileRequest.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/profile/dto/request/AdminProfileRequest.java
@@ -1,0 +1,10 @@
+package ready_to_marry.adminservice.profile.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class AdminProfileRequest {
+    private String name;
+    private String department;
+    private String phone;
+}

--- a/AdminService/src/main/java/ready_to_marry/adminservice/profile/dto/response/AdminIdResponse.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/profile/dto/response/AdminIdResponse.java
@@ -1,0 +1,13 @@
+package ready_to_marry.adminservice.profile.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminIdResponse {
+
+    @JsonProperty("admin_id")
+    private Long adminId;
+}

--- a/AdminService/src/main/java/ready_to_marry/adminservice/profile/entity/Admin.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/profile/entity/Admin.java
@@ -1,0 +1,29 @@
+package ready_to_marry.adminservice.profile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "admin", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"name", "department", "phone"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Admin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "admin_id")
+    private Long adminId;
+
+    @Column(name = "name", nullable = false, length = 20)
+    private String name;
+
+    @Column(name = "department", nullable = false, length = 20)
+    private String department;
+
+    @Column(name = "phone", nullable = false, length = 20)
+    private String phone;
+}

--- a/AdminService/src/main/java/ready_to_marry/adminservice/profile/repository/AdminRepository.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/profile/repository/AdminRepository.java
@@ -1,0 +1,13 @@
+package ready_to_marry.adminservice.profile.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ready_to_marry.adminservice.profile.entity.Admin;
+
+import java.util.Optional;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Optional<Admin> findByNameAndDepartmentAndPhone(String name, String department, String phone);
+}

--- a/AdminService/src/main/java/ready_to_marry/adminservice/profile/service/InternalAdminService.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/profile/service/InternalAdminService.java
@@ -1,0 +1,28 @@
+package ready_to_marry.adminservice.profile.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import ready_to_marry.adminservice.profile.dto.request.AdminProfileRequest;
+import ready_to_marry.adminservice.profile.entity.Admin;
+import ready_to_marry.adminservice.profile.repository.AdminRepository;
+
+@Service
+@RequiredArgsConstructor
+public class InternalAdminService {
+
+    private final AdminRepository adminRepository;
+
+    public Long getOrCreateAdminId(AdminProfileRequest request) {
+        return adminRepository.findByNameAndDepartmentAndPhone(
+                        request.getName(), request.getDepartment(), request.getPhone())
+                .map(Admin::getAdminId)
+                .orElseGet(() -> {
+                    Admin newAdmin = Admin.builder()
+                            .name(request.getName())
+                            .department(request.getDepartment())
+                            .phone(request.getPhone())
+                            .build();
+                    return adminRepository.save(newAdmin).getAdminId();
+                });
+    }
+}


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 내부 서비스 간 통신을 위한 관리자 ID 조회/생성 API 추가

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정  
- [ ] 버그 수정  
- [ ] 코드 리팩토링  
- [ ] 문서 작성  
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- name, department, phone 정보를 기반으로 Admin 엔티티를 조회하거나, 존재하지 않으면 신규 생성
- 내부 전용 엔드포인트 `/internal/admin-id` 를 통해 접근
- 응답 데이터를 `{ "admin_id": Long }` 구조로 감싸기 위해 `AdminIdResponse` DTO 정의

## 📸 스크린샷 (Optional)
x

## 🔗 관련 이슈 (Linked Issue)
x

## 📌 참고 사항 (Additional Notes)
x