### PR TITLE
Chore: 주요 서비스에 Slf4j 로깅 추가

### DIFF
--- a/AdminService/src/main/java/ready_to_marry/adminservice/common/exception/GlobalExceptionHandler.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/common/exception/GlobalExceptionHandler.java
@@ -1,18 +1,33 @@
 package ready_to_marry.adminservice.common.exception;
 
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import ready_to_marry.adminservice.common.dto.ApiResponse;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
+    // 1. NotFoundException (예: 비즈니스 예외 - 404)
     @ExceptionHandler(NotFoundException.class)
     public ApiResponse<Void> handleNotFoundException(NotFoundException ex) {
         return ApiResponse.error(404, ex.getMessage());
     }
 
+    // 2. BusinessException (예: 유효성, 요청 불가 등)
+    @ExceptionHandler(BusinessException.class)
+    public ApiResponse<Void> handleBusinessException(BusinessException ex) {
+        return ApiResponse.error(ex.getCode(), ex.getMessage());
+    }
+
+    // 3. InfrastructureException (예: DB, 외부 API 오류 등)
+    @ExceptionHandler(InfrastructureException.class)
+    public ApiResponse<Void> handleInfraException(InfrastructureException ex) {
+        return ApiResponse.error(ex.getCode(), "시스템 오류가 발생했습니다. 관리자에게 문의하세요.");
+    }
+
+    // 4. 예상 못 한 예외 (fallback)
     @ExceptionHandler(Exception.class)
     public ApiResponse<Void> handleAll(Exception ex) {
         return ApiResponse.error(500, "서버 오류가 발생했습니다.");

--- a/AdminService/src/main/java/ready_to_marry/adminservice/common/exception/InfrastructureException.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/common/exception/InfrastructureException.java
@@ -1,4 +1,15 @@
 package ready_to_marry.adminservice.common.exception;
 
-public class InfrastructureException {
+import lombok.Getter;
+
+@Getter
+public class InfrastructureException extends RuntimeException {
+
+    private final int code;
+
+    public InfrastructureException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+
 }

--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/service/CouponServiceImpl.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/service/CouponServiceImpl.java
@@ -2,6 +2,7 @@ package ready_to_marry.adminservice.event.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import ready_to_marry.adminservice.common.exception.NotFoundException;
 import ready_to_marry.adminservice.event.dto.request.CouponRequest;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CouponServiceImpl implements CouponService {
@@ -24,38 +26,50 @@ public class CouponServiceImpl implements CouponService {
     @Transactional
     public CouponDetailResponse createCoupon(CouponRequest request, Long adminId) {
         Coupon coupon = couponRepository.save(Coupon.from(request, adminId));
+        log.info("[쿠폰 등록] 성공 - couponId={}, title={}, adminId={}",
+                coupon.getCouponId(), coupon.getTitle(), adminId);
         return CouponDetailResponse.from(coupon);
     }
 
-    // 2. 쿠폰 수정 (adminId 반영)
+    // 2. 쿠폰 수정
     @Override
     @Transactional
     public void updateCoupon(Long couponId, CouponRequest request, Long adminId) {
         Coupon coupon = couponRepository.findById(couponId)
-                .orElseThrow(() -> new NotFoundException("해당 쿠폰을 찾을 수 없습니다."));
-        coupon.updateFrom(request, adminId); // 수정자 기록
+                .orElseThrow(() -> {
+                    log.warn("[쿠폰 수정 실패] 존재하지 않는 쿠폰 - couponId={}", couponId);
+                    return new NotFoundException("해당 쿠폰을 찾을 수 없습니다.");
+                });
+
+        coupon.updateFrom(request, adminId);
+        log.info("[쿠폰 수정] 성공 - couponId={}, adminId={}, newTitle={}",
+                couponId, adminId, request.getTitle());
     }
 
-    // 3. 쿠폰 삭제 (adminId 검증 or 기록 목적)
+    // 3. 쿠폰 삭제
     @Override
     @Transactional
     public void deleteCoupon(Long couponId, Long adminId) {
         Coupon coupon = couponRepository.findById(couponId)
-                .orElseThrow(() -> new NotFoundException("해당 쿠폰을 찾을 수 없습니다."));
-
-        // Optional: 삭제 권한 검증
-        // if (!coupon.getCreatedBy().equals(adminId)) {
-        //     throw new AccessDeniedException("삭제 권한이 없습니다.");
-        // }
+                .orElseThrow(() -> {
+                    log.warn("[쿠폰 삭제 실패] 존재하지 않는 쿠폰 - couponId={}", couponId);
+                    return new NotFoundException("해당 쿠폰을 찾을 수 없습니다.");
+                });
 
         couponRepository.delete(coupon);
+        log.info("[쿠폰 삭제] 성공 - couponId={}, adminId={}", couponId, adminId);
     }
 
     // 4. 쿠폰 상세 조회
     @Override
     public CouponDetailResponse getCoupon(Long couponId) {
         Coupon coupon = couponRepository.findById(couponId)
-                .orElseThrow(() -> new NotFoundException("해당 쿠폰을 찾을 수 없습니다."));
+                .orElseThrow(() -> {
+                    log.warn("[쿠폰 상세 조회 실패] 존재하지 않는 쿠폰 - couponId={}", couponId);
+                    return new NotFoundException("해당 쿠폰을 찾을 수 없습니다.");
+                });
+
+        log.debug("[쿠폰 상세 조회] 성공 - couponId={}", couponId);
         return CouponDetailResponse.from(coupon);
     }
 
@@ -64,32 +78,50 @@ public class CouponServiceImpl implements CouponService {
     @Transactional
     public CouponDetailResponse issueCoupon(Long couponId, Long userId) {
         Coupon coupon = couponRepository.findById(couponId)
-                .orElseThrow(() -> new NotFoundException("해당 쿠폰을 찾을 수 없습니다."));
+                .orElseThrow(() -> {
+                    log.warn("[쿠폰 발급 실패] 존재하지 않는 쿠폰 - couponId={}, userId={}", couponId, userId);
+                    return new NotFoundException("해당 쿠폰을 찾을 수 없습니다.");
+                });
 
         LocalDateTime now = LocalDateTime.now();
-        if (!coupon.isActive()) throw new IllegalStateException("쿠폰이 비활성화 상태입니다.");
+        if (!coupon.isActive()) {
+            log.warn("[쿠폰 발급 실패] 비활성 상태 - couponId={}, userId={}", couponId, userId);
+            throw new IllegalStateException("쿠폰이 비활성화 상태입니다.");
+        }
         if (now.isBefore(coupon.getIssuedFrom()) || now.isAfter(coupon.getIssuedUntil())) {
+            log.warn("[쿠폰 발급 실패] 기간 외 요청 - couponId={}, userId={}, now={}, from={}, until={}",
+                    couponId, userId, now, coupon.getIssuedFrom(), coupon.getIssuedUntil());
             throw new IllegalStateException("현재는 쿠폰 발급 기간이 아닙니다.");
         }
         if (coupon.getIssuedQuantity() >= coupon.getTotalQuantity()) {
+            log.warn("[쿠폰 발급 실패] 소진 완료 - couponId={}, issued={}, total={}",
+                    couponId, coupon.getIssuedQuantity(), coupon.getTotalQuantity());
             throw new IllegalStateException("쿠폰이 모두 소진되었습니다.");
         }
 
         coupon.setIssuedQuantity(coupon.getIssuedQuantity() + 1);
+        log.info("[쿠폰 발급 성공] couponId={}, userId={}, issuedQuantity={}",
+                couponId, userId, coupon.getIssuedQuantity());
+
         return CouponDetailResponse.from(coupon);
     }
 
-    // 6. 쿠폰 엔티티 반환 (내부 용도)
+    // 6. 쿠폰 엔티티 조회 (내부 용도)
     @Override
     public Coupon getCouponEntity(Long couponId) {
         return couponRepository.findById(couponId)
-                .orElseThrow(() -> new NotFoundException("해당 쿠폰을 찾을 수 없습니다."));
+                .orElseThrow(() -> {
+                    log.warn("[쿠폰 엔티티 조회 실패] 존재하지 않는 쿠폰 - couponId={}", couponId);
+                    return new NotFoundException("해당 쿠폰을 찾을 수 없습니다.");
+                });
     }
 
     // 7. 전체 쿠폰 목록 조회
     @Override
     public List<CouponDetailResponse> getAllCoupons() {
-        return couponRepository.findAll().stream()
+        List<Coupon> list = couponRepository.findAll();
+        log.debug("[쿠폰 전체 목록 조회] {}건 반환", list.size());
+        return list.stream()
                 .map(CouponDetailResponse::from)
                 .collect(Collectors.toList());
     }

--- a/AdminService/src/main/java/ready_to_marry/adminservice/event/service/EventServiceImpl.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/event/service/EventServiceImpl.java
@@ -2,6 +2,7 @@ package ready_to_marry.adminservice.event.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,6 +20,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EventServiceImpl implements EventService {
@@ -31,14 +33,16 @@ public class EventServiceImpl implements EventService {
     @Override
     @Transactional
     public void createEvent(EventCreateRequest request, MultipartFile image, Long adminId) {
+        log.info("[이벤트 등록] 요청 - adminId={}, title={}, linkType={}, targetId={}",
+                adminId, request.getTitle(), request.getLinkType(), request.getTargetId());
+
         Long targetId = request.getTargetId();
 
-        // 1) 먼저 이벤트 저장 (이미지 제외)
         Event event = Event.builder()
                 .linkType(request.getLinkType())
                 .title(request.getTitle())
-                .thumbnailImageUrl("") // 이미지 추후 설정
-                .linkUrl("") // 추후 설정
+                .thumbnailImageUrl("")
+                .linkUrl("")
                 .targetId(targetId)
                 .startDate(request.getStartDate())
                 .endDate(request.getEndDate())
@@ -46,14 +50,12 @@ public class EventServiceImpl implements EventService {
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        eventRepository.save(event); // ID 생성
+        eventRepository.save(event);
 
-        // 2) 이미지 업로드
         Long eventId = event.getEventId();
         String imageKey = String.format("admin/events/event-%d.jpg", eventId);
         String imageUrl = s3Uploader.uploadWithKey(image, imageKey);
 
-        // 3) 이미지 URL, 링크 설정
         event.setThumbnailImageUrl(imageUrl);
 
         String linkUrl = (request.getLinkType() == LinkType.CE)
@@ -61,75 +63,97 @@ public class EventServiceImpl implements EventService {
                 : "/catalog-service/items/" + targetId + "/details";
 
         event.setLinkUrl(linkUrl);
+
+        log.info("[이벤트 등록 완료] eventId={}, linkUrl={}, imageUrl={}",
+                eventId, linkUrl, imageUrl);
     }
 
     // 2. Admin -> 이벤트 수정
     @Override
     @Transactional
     public void updateEvent(Long eventId, EventUpdateRequest request, MultipartFile image, Long adminId) {
+        log.info("[이벤트 수정] 요청 - eventId={}, adminId={}, newTitle={}",
+                eventId, adminId, request.getTitle());
+
         Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new NotFoundException("이벤트를 찾을 수 없습니다."));
+                .orElseThrow(() -> {
+                    log.warn("[이벤트 수정 실패] 존재하지 않음 - eventId={}", eventId);
+                    return new NotFoundException("이벤트를 찾을 수 없습니다.");
+                });
 
-
-        // 1) 이미지가 있으면 새로 업로드
         if (image != null && !image.isEmpty()) {
             String imageKey = String.format("admin/events/event-%d.jpg", eventId);
             String imageUrl = s3Uploader.uploadWithKey(image, imageKey);
             event.setThumbnailImageUrl(imageUrl);
+            log.info("[이벤트 수정] 썸네일 이미지 업데이트 - eventId={}, imageUrl={}", eventId, imageUrl);
         }
 
-        // 2) 필드 갱신
-        String title = request.getTitle();
-        LocalDateTime startDate = request.getStartDate();
-        LocalDateTime endDate = request.getEndDate();
+        if (request.getTitle() != null && !request.getTitle().isEmpty()) {
+            event.setTitle(request.getTitle());
+        }
+        if (request.getStartDate() != null) {
+            event.setStartDate(request.getStartDate());
+        }
+        if (request.getEndDate() != null) {
+            event.setEndDate(request.getEndDate());
+        }
 
-        if (title != null && !title.isEmpty()) {
-            event.setTitle(title);
-        }
-        if (startDate != null) {
-            event.setStartDate(startDate);
-        }
-        if (endDate != null) {
-            event.setEndDate(endDate);
-        }
+        log.info("[이벤트 수정 완료] eventId={}, updatedTitle={}", eventId, event.getTitle());
     }
 
     // 3. 이벤트 삭제
     @Override
     @Transactional
     public void deleteEvent(Long eventId, Long adminId) {
-        Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new NotFoundException("이벤트를 찾을 수 없습니다."));
-        eventRepository.delete(event);
+        log.info("[이벤트 삭제] 요청 - eventId={}, adminId={}", eventId, adminId);
 
-        // 이미지도 삭제할 경우
-        // String imageKey = String.format("admin/events/event-%d.jpg", eventId);
-        // s3Uploader.delete(imageKey);
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> {
+                    log.warn("[이벤트 삭제 실패] 존재하지 않음 - eventId={}", eventId);
+                    return new NotFoundException("이벤트를 찾을 수 없습니다.");
+                });
+
+        eventRepository.delete(event);
+        log.info("[이벤트 삭제 완료] eventId={}", eventId);
+
+        // S3 이미지 삭제 로직이 필요한 경우 추가 가능
     }
 
-    // 4. User -> 이벤트 조회 -> 상세 조회
+    // 4. User -> 이벤트 상세 조회
     @Override
     public EventDetailResponse getEventDetail(Long eventId) {
+        log.debug("[이벤트 상세 조회] 요청 - eventId={}", eventId);
+
         Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new NotFoundException("이벤트를 찾을 수 없습니다."));
+                .orElseThrow(() -> {
+                    log.warn("[이벤트 상세 조회 실패] 존재하지 않음 - eventId={}", eventId);
+                    return new NotFoundException("이벤트를 찾을 수 없습니다.");
+                });
 
         if (event.getLinkType() == LinkType.CE) {
             Coupon coupon = couponService.getCouponEntity(event.getTargetId());
+            log.info("[이벤트 상세 조회 완료] 쿠폰 이벤트 - eventId={}, couponId={}",
+                    eventId, coupon.getCouponId());
             return EventDetailResponse.from(coupon, event);
         }
 
+        log.warn("[이벤트 상세 조회 실패] 쿠폰 이벤트 아님 - eventId={}, linkType={}",
+                eventId, event.getLinkType());
         throw new IllegalStateException("쿠폰 이벤트가 아닌 이벤트는 상세 정보를 제공하지 않습니다.");
     }
 
     // 5. User -> 전체 이벤트 목록 조회
     @Override
     public EventPagedResponse getPagedEvents(int page, int size) {
+        log.debug("[이벤트 목록 조회] 요청 - page={}, size={}", page, size);
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
         Page<Event> result = eventRepository.findAll(pageable);
 
         List<EventDTO> items = result.getContent().stream()
                 .map(EventDTO::from)
                 .collect(Collectors.toList());
+
+        log.info("[이벤트 목록 조회 완료] 총 {}건", result.getTotalElements());
 
         return EventPagedResponse.builder()
                 .items(items)
@@ -142,9 +166,13 @@ public class EventServiceImpl implements EventService {
     // 6. Admin → 전체 이벤트 목록 조회
     @Override
     public List<AdminEventResponse> getAdminEventList() {
-        return eventRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"))
+        log.debug("[이벤트 전체 조회 - 관리자] 요청");
+        List<AdminEventResponse> list = eventRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"))
                 .stream()
                 .map(AdminEventResponse::from)
                 .collect(Collectors.toList());
+        log.info("[이벤트 전체 조회 완료 - 관리자] {}건 반환", list.size());
+        return list;
     }
 }
+

--- a/AdminService/src/main/java/ready_to_marry/adminservice/mainbanner/service/MainBannerServiceImpl.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/mainbanner/service/MainBannerServiceImpl.java
@@ -2,6 +2,7 @@ package ready_to_marry.adminservice.mainbanner.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import ready_to_marry.adminservice.mainbanner.dto.request.MainBannerRequest;
 import ready_to_marry.adminservice.mainbanner.dto.response.AdminMainBannerResponse;
@@ -17,6 +18,7 @@ import ready_to_marry.adminservice.trendpost.repository.TrendPostRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MainBannerServiceImpl implements MainBannerService {
@@ -29,6 +31,9 @@ public class MainBannerServiceImpl implements MainBannerService {
     @Transactional
     @Override
     public void register(MainBannerRequest request, Long adminId) {
+        log.info("[메인배너 등록] 요청 - adminId={}, type={}, refId={}, priority={}",
+                adminId, request.getType(), request.getRefId(), request.getPriority());
+
         MainBanner banner = MainBanner.builder()
                 .type(request.getType())
                 .refId(request.getRefId())
@@ -36,29 +41,51 @@ public class MainBannerServiceImpl implements MainBannerService {
                 .createdBy(adminId)
                 .build();
         bannerRepository.save(banner);
+
+        log.info("[메인배너 등록 완료] bannerId={}, refId={}, type={}",
+                banner.getMainBannerId(), banner.getRefId(), banner.getType());
     }
 
     // 2. 메인 배너 수정 (Admin)
     @Transactional
     @Override
     public void update(Long mainBannerId, MainBannerRequest request, Long adminId) {
+        log.info("[메인배너 수정] 요청 - bannerId={}, adminId={}, newRefId={}, newType={}, newPriority={}",
+                mainBannerId, adminId, request.getRefId(), request.getType(), request.getPriority());
+
         MainBanner banner = bannerRepository.findById(mainBannerId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 배너입니다."));
+                .orElseThrow(() -> {
+                    log.warn("[메인배너 수정 실패] 존재하지 않음 - bannerId={}", mainBannerId);
+                    return new IllegalArgumentException("존재하지 않는 배너입니다.");
+                });
+
         banner.update(request.getType(), request.getRefId(), request.getPriority(), adminId);
+
+        log.info("[메인배너 수정 완료] bannerId={}, updatedRefId={}, updatedType={}",
+                mainBannerId, request.getRefId(), request.getType());
     }
 
     // 3. 메인 배너 삭제 (Admin)
     @Transactional
     @Override
     public void delete(Long id, Long adminId) {
+        log.info("[메인배너 삭제] 요청 - bannerId={}, adminId={}", id, adminId);
+
         MainBanner banner = bannerRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 배너입니다."));
+                .orElseThrow(() -> {
+                    log.warn("[메인배너 삭제 실패] 존재하지 않음 - bannerId={}", id);
+                    return new IllegalArgumentException("존재하지 않는 배너입니다.");
+                });
+
         bannerRepository.delete(banner);
+
+        log.info("[메인배너 삭제 완료] bannerId={}", id);
     }
 
     // 4. 메인 배너 전체 목록 조회 (Admin - 상세 정보 포함)
     @Override
     public List<AdminMainBannerResponse> getAdminAll() {
+        log.debug("[메인배너 전체 조회 - 관리자] 요청");
         return bannerRepository.findAllByOrderByPriorityAsc().stream()
                 .map(this::toAdminResponse)
                 .collect(Collectors.toList());
@@ -67,6 +94,7 @@ public class MainBannerServiceImpl implements MainBannerService {
     // 5. 메인 배너 전체 목록 조회 (User - 썸네일, 링크만 제공)
     @Override
     public List<MainBannerResponse> getAll() {
+        log.debug("[메인배너 전체 조회 - 사용자] 요청");
         return bannerRepository.findAllByOrderByPriorityAsc().stream()
                 .map(this::toResponse)
                 .collect(Collectors.toList());
@@ -76,7 +104,10 @@ public class MainBannerServiceImpl implements MainBannerService {
     private MainBannerResponse toResponse(MainBanner banner) {
         if (banner.getType() == BannerType.EVENT) {
             Event event = eventRepository.findById(banner.getRefId())
-                    .orElseThrow(() -> new IllegalArgumentException("이벤트 정보 없음"));
+                    .orElseThrow(() -> {
+                        log.error("[메인배너 변환 실패 - 사용자] 이벤트 정보 없음 - refId={}", banner.getRefId());
+                        return new IllegalArgumentException("이벤트 정보 없음");
+                    });
 
             return MainBannerResponse.builder()
                     .mainBannerId(banner.getMainBannerId())
@@ -85,7 +116,10 @@ public class MainBannerServiceImpl implements MainBannerService {
                     .build();
         } else {
             TrendPost post = trendPostRepository.findById(banner.getRefId())
-                    .orElseThrow(() -> new IllegalArgumentException("트렌드포스트 정보 없음"));
+                    .orElseThrow(() -> {
+                        log.error("[메인배너 변환 실패 - 사용자] 트렌드포스트 정보 없음 - refId={}", banner.getRefId());
+                        return new IllegalArgumentException("트렌드포스트 정보 없음");
+                    });
 
             return MainBannerResponse.builder()
                     .mainBannerId(banner.getMainBannerId())
@@ -99,7 +133,10 @@ public class MainBannerServiceImpl implements MainBannerService {
     private AdminMainBannerResponse toAdminResponse(MainBanner banner) {
         if (banner.getType() == BannerType.EVENT) {
             Event event = eventRepository.findById(banner.getRefId())
-                    .orElseThrow(() -> new IllegalArgumentException("이벤트 정보 없음"));
+                    .orElseThrow(() -> {
+                        log.error("[메인배너 변환 실패 - 관리자] 이벤트 정보 없음 - refId={}", banner.getRefId());
+                        return new IllegalArgumentException("이벤트 정보 없음");
+                    });
 
             return AdminMainBannerResponse.builder()
                     .mainBannerId(banner.getMainBannerId())
@@ -111,7 +148,10 @@ public class MainBannerServiceImpl implements MainBannerService {
                     .build();
         } else {
             TrendPost post = trendPostRepository.findById(banner.getRefId())
-                    .orElseThrow(() -> new IllegalArgumentException("트렌드포스트 정보 없음"));
+                    .orElseThrow(() -> {
+                        log.error("[메인배너 변환 실패 - 관리자] 트렌드포스트 정보 없음 - refId={}", banner.getRefId());
+                        return new IllegalArgumentException("트렌드포스트 정보 없음");
+                    });
 
             return AdminMainBannerResponse.builder()
                     .mainBannerId(banner.getMainBannerId())

--- a/AdminService/src/main/java/ready_to_marry/adminservice/notice/service/NoticeServiceImpl.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/notice/service/NoticeServiceImpl.java
@@ -1,6 +1,7 @@
 package ready_to_marry.adminservice.notice.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -18,24 +19,26 @@ import ready_to_marry.adminservice.notice.repository.NoticeRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NoticeServiceImpl implements NoticeService {
 
     private final NoticeRepository repository;
 
-    // 1. 공지사항 전체 목록 조회 (페이징 없음, 기존 메서드)
+    // 1. 공지사항 전체 목록 조회 (디버깅용)
     @Override
     public List<NoticeDTO> getAll() {
+        log.debug("[공지사항 목록 조회] 요청 - 전체");
         return repository.findAll().stream()
                 .map(NoticeDTO::from)
                 .collect(Collectors.toList());
     }
 
-
-    // 2. 페이징 처리된 공지사항 목록 조회 추가
+    // 2. 페이징 목록 조회
     @Override
     public NoticeListResponse getAllPaged(int page, int size) {
+        log.debug("[공지사항 목록 조회] 요청 - page={}, size={}", page, size);
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<Notice> noticePage = repository.findAll(pageable);
 
@@ -43,19 +46,20 @@ public class NoticeServiceImpl implements NoticeService {
                 .map(NoticeDTO::from)
                 .collect(Collectors.toList());
 
-        return new NoticeListResponse(
-                items,
-                page,
-                size,
-                noticePage.getTotalElements()
-        );
+        return new NoticeListResponse(items, page, size, noticePage.getTotalElements());
     }
 
     // 3. 공지사항 상세 조회
     @Override
     public NoticeDetailResponse getById(Long id) {
+        log.debug("[공지사항 단건 조회] 요청 - id={}", id);
+
         Notice notice = repository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("[공지사항 조회 실패] 존재하지 않음 - id={}", id);
+                    return new BusinessException(ErrorCode.NOT_FOUND);
+                });
+
         return NoticeDetailResponse.from(notice);
     }
 
@@ -63,42 +67,60 @@ public class NoticeServiceImpl implements NoticeService {
     @Override
     @Transactional
     public NoticeDetailResponse create(NoticeRequest request, Long adminId) {
+        log.info("[공지사항 등록] 요청 - adminId={}, title={}", adminId, request.getTitle());
+
         Notice saved = repository.save(Notice.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
                 .adminId(adminId)
                 .build());
+
+        log.info("[공지사항 등록 완료] noticeId={}, title={}", saved.getNoticeId(), saved.getTitle());
         return NoticeDetailResponse.from(saved);
     }
 
     // 5. 공지사항 수정
-    @Transactional
     @Override
+    @Transactional
     public NoticeDetailResponse update(Long id, NoticeRequest request, Long adminId) {
+        log.info("[공지사항 수정] 요청 - id={}, adminId={}, newTitle={}", id, adminId, request.getTitle());
+
         Notice notice = repository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("[공지사항 수정 실패] 존재하지 않음 - id={}", id);
+                    return new BusinessException(ErrorCode.NOT_FOUND);
+                });
 
         if (!notice.getAdminId().equals(adminId)) {
+            log.warn("[공지사항 수정 실패] 권한 없음 - id={}, adminId={}", id, adminId);
             throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         notice.setTitle(request.getTitle());
         notice.setContent(request.getContent());
 
+        log.info("[공지사항 수정 완료] id={}, newTitle={}", id, request.getTitle());
         return NoticeDetailResponse.from(notice);
     }
 
     // 6. 공지사항 삭제
-    @Transactional
     @Override
+    @Transactional
     public void delete(Long id, Long adminId) {
+        log.info("[공지사항 삭제] 요청 - id={}, adminId={}", id, adminId);
+
         Notice notice = repository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("[공지사항 삭제 실패] 존재하지 않음 - id={}", id);
+                    return new BusinessException(ErrorCode.NOT_FOUND);
+                });
 
         if (!notice.getAdminId().equals(adminId)) {
+            log.warn("[공지사항 삭제 실패] 권한 없음 - id={}, adminId={}", id, adminId);
             throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         repository.delete(notice);
+        log.info("[공지사항 삭제 완료] id={}", id);
     }
 }

--- a/AdminService/src/main/java/ready_to_marry/adminservice/profile/service/InternalAdminService.java
+++ b/AdminService/src/main/java/ready_to_marry/adminservice/profile/service/InternalAdminService.java
@@ -1,6 +1,7 @@
 package ready_to_marry.adminservice.profile.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import ready_to_marry.adminservice.profile.dto.request.AdminProfileRequest;
 import ready_to_marry.adminservice.profile.entity.Admin;
@@ -8,21 +9,35 @@ import ready_to_marry.adminservice.profile.repository.AdminRepository;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class InternalAdminService {
 
     private final AdminRepository adminRepository;
 
     public Long getOrCreateAdminId(AdminProfileRequest request) {
+        log.info("[AdminProfile] 요청 정보 - name: {}, department: {}, phone: {}",
+                request.getName(), request.getDepartment(), request.getPhone());
+
         return adminRepository.findByNameAndDepartmentAndPhone(
                         request.getName(), request.getDepartment(), request.getPhone())
-                .map(Admin::getAdminId)
+                .map(admin -> {
+                    log.info("[AdminProfile] 기존 관리자 조회됨 - adminId: {}", admin.getAdminId());
+                    return admin.getAdminId();
+                })
                 .orElseGet(() -> {
-                    Admin newAdmin = Admin.builder()
-                            .name(request.getName())
-                            .department(request.getDepartment())
-                            .phone(request.getPhone())
-                            .build();
-                    return adminRepository.save(newAdmin).getAdminId();
+                    try {
+                        Admin newAdmin = Admin.builder()
+                                .name(request.getName())
+                                .department(request.getDepartment())
+                                .phone(request.getPhone())
+                                .build();
+                        Admin saved = adminRepository.save(newAdmin);
+                        log.info("[AdminProfile] 신규 관리자 생성됨 - adminId: {}", saved.getAdminId());
+                        return saved.getAdminId();
+                    } catch (Exception e) {
+                        log.error("[AdminProfile] 관리자 생성 중 예외 발생", e);
+                        throw e; // 그대로 전파 → GlobalExceptionHandler에서 처리됨
+                    }
                 });
     }
 }


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 주요 서비스 로직에 Slf4j 기반의 운영 로그 추가
- 요청 흐름과 예외 상황 추척

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정  
- [ ] 버그 수정  
- [ ] 코드 리팩토링  
- [ ] 문서 작성  
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- `TrendPostServiceImpl`, `InternalAdminService` 등 주요 서비스 클래스에 `@Slf4j` 어노테이션 적용
- 다음 이벤트에 대해 로그 레벨을 나눠 기록:
  - `INFO`: 생성/수정/삭제 요청, 성공 처리
  - `WARN`: 권한 없음, 존재하지 않는 리소스 등 비정상적 흐름
  - `ERROR`: 예외 발생 시 전체 스택 포함 로깅

## 📸 스크린샷 (Optional)
x

## 🔗 관련 이슈 (Linked Issue)
x

## 📌 참고 사항 (Additional Notes)
x
