### PR TITLE
chore: logback-spring.xml 추가

### DIFF
--- a/AdminService/src/main/resources/logback-spring.xml
+++ b/AdminService/src/main/resources/logback-spring.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <timeZone>Asia/Seoul</timeZone>
+                </timestamp>
+                <pattern>
+                    <pattern>
+                        {
+                        "level": "%level",
+                        "thread": "%thread",
+                        "logger": "%logger",
+                        "message": "%message",
+                        "context": "%mdc"
+                        }
+                    </pattern>
+                </pattern>
+                <stackTrace/>
+            </providers>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- Fluentd, Grafana Loki와 연동을 위한 로그 설정을 위한 `logback-spring.xml` 파일 추가

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정 (`logback-spring.xml`)
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- 로그 레벨에 따라 console과 file에 동시에 로그를 출력하도록 설정
- 로그 파일은 `/logs/admin-service.log`에 저장되며, 일별로 rolling 처리됨
- 로그 포맷: 시간, 레벨, 스레드, 클래스명, 메시지 포함
- 추후 Fluentd, Grafana Loki와 연동 시 활용 가능

## 📸 스크린샷 (Optional)
x

## 🔗 관련 이슈 (Linked Issue)
x

## 📌 참고 사항 (Additional Notes)
x
