### PR TITLE
feat: Micrometer-Prometheus 레지스트리 추가 및 Actuator 엔드포인트 확장 설정

### DIFF
--- a/AdminService/build.gradle
+++ b/AdminService/build.gradle
@@ -41,11 +41,13 @@ dependencies {
     // PostgreSQL JDBC Driver
     implementation 'org.postgresql:postgresql:42.2.5'
 
-    // Spring Boot Actuator (Health Check용)
+    // Spring Boot Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    // eureka client
+    // Micrometer-Registry
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // eureka client
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.547' // 최신 버전 확인

--- a/AdminService/src/main/resources/application.properties
+++ b/AdminService/src/main/resources/application.properties
@@ -26,8 +26,11 @@ cloud.aws.region.static=${AWS_REGION}
 cloud.aws.stack.auto=false
 cloud.aws.s3.bucket=${AWS_S3_BUCKET_NAME}
 
-#/actuator/health
-management.endpoints.web.exposure.include=health
+# /actuator
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoint.prometheus.enabled=true
+management.endpoints.web.base-path=/actuator
+management.prometheus.metrics.export.enabled=true
 
 # Eureka
 spring.application.name=admin-service


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- Micrometer-Prometheus 레지스트리를 도입하고, Actuator 엔드포인트 노출 범위를 헬스체크뿐 아니라 정보·메트릭·Prometheus 스크랩용까지 확장했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- build.gradle
   - io.micrometer:micrometer-registry-prometheus 의존성 추가

- application.properties
   - management.endpoints.web.exposure.include 설정을 health → health,info,metrics,prometheus로 변경
   - management.endpoint.prometheus.enabled=true로 Prometheus 스크랩 엔드포인트 활성화
   - management.endpoints.web.base-path=/actuator 지정
   - management.prometheus.metrics.export.enabled=true로 Micrometer → Prometheus 내보내기 활성화

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
